### PR TITLE
adds forgotten password/reset feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@ Custom parse-server for GoodQuestion app:
  - Babel transpiler
  - cloud code
  - S3 adapter
- - custom mailgun templates
+ - custom AmazonSES email templates
 
 ## Create settings.json
 ```
 {
+  "verbose": true,
   "serverURL": "http://localhost:1337/parse",
   "databaseURI": "mongodb://localhost:27017/localparse",
   "cloud": "./cloud/main.js",
@@ -36,11 +37,12 @@ Custom parse-server for GoodQuestion app:
     }
   },
   "emailAdapter": {
-    "module": "parse-server-mailgun",
+    "module": "parse-server-amazon-ses-email-adapter",
     "options": {
-      "fromAddress": "project.super@cool.com",
-      "domain": "cool.com",
-      "apiKey": "asdfasdfasdfasdfadsfdasdfasdfasdfas",
+      fromAddress: 'Your Name <noreply@supercoolapp.com>',
+      accessKeyId: 'Your AWS IAM Access Key ID',
+      secretAccessKey: 'Your AWS IAM Secret Access Key',
+      region: 'Your AWS Region',
       "templates" : {}
     }
   }
@@ -55,9 +57,9 @@ See https://github.com/ParsePlatform/parse-server/wiki/Push
 
 See https://github.com/parse-server-modules/parse-server-s3-adapter
 
-## Mailgun Adapter
+## AmazonSES Email Adapter
 
-See https://github.com/sebsylvester/parse-server-mailgun
+See https://github.com/ecohealthalliance/parse-server-amazon-ses-email-adapter
 
 ## Installation
 ```
@@ -68,6 +70,10 @@ npm install
 ## Start
 ```
 npm start
+```
+### Start in Development mode
+```
+npm run dev
 ```
 
 ## Test Cloud Code

--- a/app.js
+++ b/app.js
@@ -36,6 +36,16 @@ const api = new ParseServer(settings);
 // Serve the Parse API at /parse URL prefix
 app.use('/parse', api);
 
+// Redirect to custom scheme; this prevents Gmail and other email clients from
+// removing schema that is not http/https.
+// See: http://stackoverflow.com/questions/23575553/ios-deep-linking-is-stripped-out-in-gmail
+app.get('/verifyForgotPassword', (req, res) => {
+  const email = encodeURIComponent(req.query.email);
+  const token = encodeURIComponent(req.query.token);
+  const url = `${settings.emailAdapter.customScheme}/verifyForgotPassword?email=${email}&token=${token}`;
+  return res.redirect(url);
+});
+
 const port = 1337;
 app.listen(port, function() {
   console.log(`parse-server-example running on port: ${port}`);

--- a/app.js
+++ b/app.js
@@ -3,22 +3,30 @@ import { ParseServer } from 'parse-server';
 import settings from './settings';
 import { resolve } from 'path';
 
-process.env.VERBOSE=true;
+process.env.VERBOSE=settings.verbose;
 
 settings.emailAdapter.options.templates = {
   passwordResetEmail: {
-    subject: 'Reset your password',
+    subject: 'GoodQuestion Reset your password',
     pathPlainText: resolve(__dirname, 'templates/password_reset_email.txt'),
     pathHtml: resolve(__dirname, 'templates/password_reset_email.html'),
     callback: (user) => { return { username: user.get('username') }},
-    // Now you can use {{username}} in your templates
   },
   verificationEmail: {
-    subject: 'Confirm your account',
+    subject: 'GoodQuestion Confirm your Account',
     pathPlainText: resolve(__dirname, 'templates/verification_email.txt'),
     pathHtml: resolve(__dirname, 'templates/verification_email.html'),
     callback: (user) => { return { username: user.get('username') }},
-    // Now you can use {{username}} in your templates
+  },
+  forgotPasswordEmail: {
+    subject: 'GoodQuestion Forgot Password',
+    pathPlainText: resolve(__dirname, 'templates/forgot_password_email.txt'),
+    pathHtml: resolve(__dirname, 'templates/forgot_password_email.html'),
+  },
+  testEmail: {
+    subject: 'GoodQuestion Test Email',
+    pathPlainText: resolve(__dirname, 'templates/test_email.txt'),
+    pathHtml: resolve(__dirname, 'templates/test_email.html'),
   },
 };
 

--- a/cloud/main.js
+++ b/cloud/main.js
@@ -1,4 +1,176 @@
-Parse.Cloud.define('echo', (req, res) => {
-  const message = req.params.message;
-  res.success(message);
+import async from 'async';
+
+import settings from '../settings';
+
+import { getUser, parseForcePassword } from './services/user';
+import { sendTest, sendForgotPassword } from './services/email';
+import { getForgotPassword } from './services/forgotPassword';
+import { openamAuth, openamForcePassword } from './services/openam';
+import { ForgotPassword, STATUS } from './models/ForgotPassword';
+
+/**
+ * responds with the value of request.params.message
+ *
+ * @param {string} request.params.message, the message to echo
+ */
+Parse.Cloud.define('echo', (request, response) => {
+  const message = request.params.message;
+  response.success(message);
+});
+
+/**
+ * sends a test email to the specified request.params.email address
+ *
+ * @param {string} request.params.email, the email address to send
+ */
+Parse.Cloud.define('testEmail', (request, response) => {
+  if (!request.master) {
+    response.error('Unauthorized.');
+    return;
+  }
+  async.auto({
+    getUser: (cb) => {
+      getUser(request.params.email, cb);
+    },
+    sendTestEmail: ['getUser', (results, cb) => {
+      sendTest(results.getUser, cb);
+    }],
+  }, (err, results) => {
+    if (err) {
+      response.error(err);
+      return;
+    }
+    response.success(results.email);
+  });
+});
+
+/**
+ * creates a forgotPassword token and sends email to address specified
+ *
+ * @param {string} request.params.email, the email address to send
+ */
+Parse.Cloud.define('createForgotPassword', (request, response) => {
+  if (!request.master) {
+    response.error('Unauthorized.');
+    return;
+  }
+  async.auto({
+    getUser: (cb) => {
+      getUser(request.params.email, cb);
+    },
+    createForgotPassword: ['getUser', (results, cb) => {
+      ForgotPassword.create(results.getUser, cb);
+    }],
+    sendForgotPasswordEmail: ['createForgotPassword', (results, cb) => {
+      sendForgotPassword(results.getUser, results.createForgotPassword, cb);
+    }],
+  }, (err) => {
+    if (err) {
+      response.error(err);
+      return;
+    }
+    response.success(true);
+  });
+});
+
+/**
+ * verifies a forgotPassword token and set the password to the value specified
+ *
+ * @param {string} request.params.email, the email address of the user
+ * @param {string} request.params.token, the forgotPassword token
+ * @param {string} request.params.newPassword, the new password for the account
+ */
+Parse.Cloud.define('verifyForgotPassword', (request, response) => {
+  if (!request.master) {
+    response.error('Unauthorized.');
+    return;
+  }
+  async.auto({
+    // get the user object
+    getUser: (cb) => {
+      getUser(request.params.email, cb);
+    },
+    // get the forgotPassword object
+    getForgotPassword: ['getUser', (results, cb) => {
+      getForgotPassword(request.params.token, cb);
+    }],
+    // validate that the forgotPassword token belongs to the user and hasn't been used
+    validate: ['getForgotPassword', (results, cb) => {
+      const forgotPassword = results.getForgotPassword;
+      if (forgotPassword.validate(results.getUser.id)) {
+        cb(null, true);
+      } else {
+        cb('Expired token.');
+      }
+    }],
+    // authenticate against openam as an admin
+    openamAuth: ['validate', (results, cb) => {
+      if (settings.openam.disabled) {
+        cb(null, null);
+        return;
+      }
+      openamAuth(settings.openam.email, settings.openam.password, cb);
+    }],
+    // force a password change on openam with the admin token
+    openamForcePassword: ['openamAuth', (results, cb) => {
+      if (settings.openam.disabled) {
+        cb(null, null);
+        return;
+      }
+      const tokenId = results.openamAuth;
+      const username = results.getUser.get('username');
+      const newPassword = request.params.newPassword;
+      openamForcePassword(tokenId, username, newPassword, cb);
+    }],
+    // force a password change on parse-server using masterKey
+    parseForcePassword: ['openamForcePassword', (results, cb) => {
+      parseForcePassword(results.getUser, request.params.newPassword, (err, user) => {
+        if (err) {
+          // if saving to parse fails we must rollback the password on Forgerock
+          const tokenId = results.openamAuth;
+          const username = results.getUser.get('username');
+          const newPassword = request.params.newPassword;
+          openamForcePassword(tokenId, username, newPassword, (err) => {
+            // if the rollback fails the user will need to contact an
+            // administrator to get their passwords to match in both Forgerock
+            // and Parse Server.
+            if (err) {
+              cb({
+                message: 'Your account has been locked. Please email: \ngoodquestion@ecohealthalliance.org',
+              });
+              return;
+            }
+            cb({
+              message: 'Could not update your password.',
+            });
+          });
+          return;
+        }
+        cb(null, user);
+      });
+    }],
+    // we made it this far, mark the forgotPassword object as STATUS.used
+    markUsed: ['parseForcePassword', (results, cb) => {
+      const forgotPassword = results.getForgotPassword;
+      forgotPassword.set('status', STATUS.used);
+      forgotPassword.save().then(
+        () => {
+          cb(null, forgotPassword);
+        },
+        (err) => {
+          cb(err);
+        }
+      );
+    }],
+  }, (error, results) => {
+    if (error) {
+      if (error.hasOwnProperty('message')) {
+        respon.error(error.message);
+        return;
+      }
+      response.error(error);
+      return;
+    }
+    response.success(true);
+  });
 });

--- a/cloud/models/ForgotPassword.js
+++ b/cloud/models/ForgotPassword.js
@@ -1,0 +1,52 @@
+export const STATUS = {
+  new: 'new',
+  used: 'used',
+};
+const useMasterKey = {useMasterKey: true};
+
+export const ForgotPassword = Parse.Object.extend('ForgotPassword', {
+  /**
+   * Validates the model for the user and STATUS.new
+   *
+   * @param {string} userId, the id of the Parse.User
+   */
+  validate: function (userId) {
+    if (this.get('status') === STATUS.new && this.get('userId') === userId) {
+      return true;
+    }
+    return false;
+  },
+});
+
+
+/**
+ * factory method to create a ForgotPassword record
+ *
+ * @param {object} user, the Parse.User
+ */
+ForgotPassword.create = (user, done) => {
+  const forgotPassword = new ForgotPassword();
+  forgotPassword.set('userId', user.id);
+  forgotPassword.set('status', STATUS.new);
+  forgotPassword.set('date', new Date());
+  const acl = new Parse.ACL();
+  acl.setReadAccess(user, true);
+  acl.setWriteAccess(user, true);
+  acl.setRoleReadAccess('admin', true);
+  acl.setRoleWriteAccess('admin', true);
+  forgotPassword.setACL(acl);
+  forgotPassword.save(null, useMasterKey)
+  .then(
+    () => {
+      user.relation('forgotPasswords').add(forgotPassword);
+      user.save(null, useMasterKey);
+      done(null, forgotPassword);
+    },
+    (err) => {
+      done(err);
+    }
+  )
+  .fail(function(err) {
+    done(err);
+  });
+}

--- a/cloud/services/email.js
+++ b/cloud/services/email.js
@@ -1,0 +1,57 @@
+import settings from '../../settings';
+
+import { ForgotPassword, STATUS } from '../models/ForgotPassword';
+import { AppCache } from 'parse-server/lib/cache';
+
+/**
+ * Sends a custom test email.
+ * @param
+ */
+export function sendTest(user, done) {
+  const adapter = AppCache.get(settings.appId)['userController']['adapter'];
+  if (typeof adapter === 'undefined') {
+    done(new Error('Invalid mail adapter.'));
+    return;
+  }
+  adapter.send({
+    templateName: 'testEmail',
+    recipient: user.get('username'),
+    variables: { username: user.get('username') },
+  })
+  .then(
+    function(body) {
+      done(null, body);
+    }
+  ).catch(
+    function(err) {
+      done(err);
+    }
+  );
+}
+
+/**
+ * Sends an email based on a template name.
+ * @param {object} user, parse User model
+ * @param {function} done, Callback function which returns an array of Parse 'Form' objects
+ */
+export function sendForgotPassword(user, forgotPassword, done) {
+  const adapter = AppCache.get(settings.appId)['userController']['adapter'];
+  if (typeof adapter === 'undefined') {
+    done(new Error('Invalid mail adapter.'));
+    return;
+  }
+  const promise = adapter.send({
+    templateName: 'forgotPasswordEmail',
+    fromAddress: settings.emailAdapter.fromAddress,
+    recipient: user.get('username'),
+    variables: { username: user.get('username'), token: forgotPassword.id },
+  }).then(
+    (body) => {
+      done(null, body);
+    }
+  ).catch(
+    (err) => {
+      done(err);
+    }
+  );
+}

--- a/cloud/services/email.js
+++ b/cloud/services/email.js
@@ -40,11 +40,14 @@ export function sendForgotPassword(user, forgotPassword, done) {
     done(new Error('Invalid mail adapter.'));
     return;
   }
-  const promise = adapter.send({
+  const username = user.get('username');
+  const token = forgotPassword.id;
+  const link = `${settings.emailAdapter.redirectUrl}/verifyForgotPassword?email=${username}&token=${token}`;
+  adapter.send({
     templateName: 'forgotPasswordEmail',
     fromAddress: settings.emailAdapter.fromAddress,
-    recipient: user.get('username'),
-    variables: { username: user.get('username'), token: forgotPassword.id },
+    recipient: username,
+    variables: { username, token, link },
   }).then(
     (body) => {
       done(null, body);

--- a/cloud/services/forgotPassword.js
+++ b/cloud/services/forgotPassword.js
@@ -1,0 +1,25 @@
+import { ForgotPassword, STATUS } from '../models/forgotPassword';
+
+/**
+ * Gets the User from a specified username
+ * @param {string} token, the id of the ForgotPassword record
+ * @param {function} done, Callback function which returns a Parse.User object or error
+ */
+export function getForgotPassword(token, done) {
+  const query = new Parse.Query(ForgotPassword);
+  query.get(token)
+  .then(
+    (forgotPassword) => {
+      if (forgotPassword) {
+        return done(null, forgotPassword);
+      }
+      done('Invalid token ID.');
+    },
+    (err) => {
+      if (err.hasOwnProperty('message')) {
+        return done(err.message);
+      }
+      done(err);
+    }
+  );
+}

--- a/cloud/services/openam.js
+++ b/cloud/services/openam.js
@@ -1,0 +1,133 @@
+import fetch from 'node-fetch';
+import settings from '../../settings';
+
+const openam = {
+  baseUrl: settings.openam.baseUrl,
+  authPath: '/openam/json/authenticate?Content-Type=application/json',
+  regPath: '/openam/json/users/?_action=create',
+  changePasswordPath: (username) => `/openam/json/users/${username}?_action=changePassword`,
+  forcePasswordPath: (username) => `/openam/json/users/${username}`,
+};
+
+/**
+ *
+ * OpenAm admin authentication to get session of authorized user who is capable
+ * of creating user accounts.
+ *
+ * @param {string} username, the username to authenticate on openam
+ * @param {string} password, the password to authenticate on openam
+ * @param {done} done, the function to execute when done
+ * @returns {undefined}
+ */
+export function openamAuth(username, password, done) {
+  const authConfig = {
+    method: 'POST',
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+      'X-OpenAM-Username': username,
+      'X-OpenAM-Password': password,
+    },
+  };
+  const url = openam.baseUrl + openam.authPath;
+  fetch(url, authConfig).then((res) => {
+    return res.text();
+  }).then((responseText) => {
+    const jsonData = JSON.parse(responseText);
+    if (!jsonData.hasOwnProperty('tokenId')) {
+      if (jsonData.hasOwnProperty('message')) {
+        done(jsonData.message);
+        return;
+      }
+      done('Unauthorized');
+    }
+    done(null, jsonData.tokenId);
+  }).catch(() => {
+    done('Unauthorized');
+  });
+}
+
+/**
+ *
+ * OpenAm change a users password
+ *
+ * @param {done} done, the function to execute when done
+ * @returns {undefined}
+ */
+export function openamChangePassword(tokenId, username, currentPassword, newPassword, done) {
+  const authConfig = {
+    method: 'POST',
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+      'iPlanetDirectoryPro': tokenId,
+    },
+    body: JSON.stringify({
+      'currentpassword': currentPassword,
+      'userpassword': newPassword,
+    }),
+  };
+  const url = openam.baseUrl + encodeURI(openam.changePasswordPath(username));
+  fetch(url, authConfig).then((res) => {
+    if (typeof res === 'undefined') {
+      throw new Error('Bad Request.');
+    }
+    return res.text();
+  }).then((responseText) => {
+    const jsonData = JSON.parse(responseText);
+    // Forgerock does not provide descriptive errors for authorized requests
+    // that failed changePassword, such as meeting minimum complexity requirements
+    // or other password policies.
+    // https://bugster.forgerock.org/jira/browse/OPENAM-6867
+    if (jsonData.hasOwnProperty('code') && jsonData.code !== 200) {
+      done(jsonData.message);
+      return;
+    }
+    done(null, true);
+  }).catch(() => {
+    done('Unauthorized');
+  });
+}
+
+/**
+ *
+ * OpenAm force new password as admin user
+ *
+ * @param {done} done, the function to execute when done
+ * @returns {undefined}
+ */
+export function openamForcePassword(tokenId, username, newPassword, done) {
+  const authConfig = {
+    method: 'PUT',
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+      'iPlanetDirectoryPro': tokenId,
+    },
+    body: JSON.stringify({
+      'userpassword': newPassword,
+    }),
+  };
+  const url = openam.baseUrl + encodeURI(openam.forcePasswordPath(username));
+  fetch(url, authConfig).then((res) => {
+    if (typeof res === 'undefined') {
+      throw new Error('Bad Request.');
+    }
+    return res.text();
+  }).then((responseText) => {
+    const jsonData = JSON.parse(responseText);
+    // Forgerock v12 is unable to change a user password using the admin token
+    // https://bugster.forgerock.org/jira/browse/OPENAM-6443
+    if (jsonData.hasOwnProperty('code') && jsonData.code !== 200) {
+      done(jsonData.message);
+      return;
+    }
+    done(null, true);
+  }).catch((err) => {
+    if (err.hasOwnProperty('message')) {
+      done(err.message);
+      return;
+    }
+    done(err);
+  });
+}

--- a/cloud/services/user.js
+++ b/cloud/services/user.js
@@ -1,0 +1,56 @@
+import { ForgotPassword, STATUS } from '../models/ForgotPassword';
+
+/**
+ * Gets the User from a specified username
+ * @param {string} username, username of the user
+ * @param {function} done, Callback function which returns a Parse.User object or error
+ */
+export function getUser(username, done) {
+  Parse.Cloud.useMasterKey();
+  const query = new Parse.Query(Parse.User);
+  query.equalTo('username', username);
+  query.first(
+    (user) => {
+      if (user) {
+        done(null, user);
+        return;
+      }
+      done('Invalid user');
+    },
+    (err) => {
+      if (err.hasOwnProperty('message')) {
+        done(err.message);
+        return;
+      }
+      done(err);
+    }
+  );
+}
+
+/**
+ * forces a new password using masterKey
+ *
+ * @param {string} username, username of the user
+ * @param {string} password, the new password
+ * @param {function} done, callback function which returns a Parse.User object or error
+ */
+export function parseForcePassword(user, password, done) {
+  Parse.Cloud.useMasterKey();
+  user.set('password', password);
+  user.save().then(
+    () => {
+      done(null, user);
+    },
+    (err) => {
+      if (err.hasOwnProperty('message')) {
+        done(err.message);
+        return;
+      }
+      done(err);
+    }
+  ).fail(
+    (err) => {
+      done(err);
+    }
+  );
+}

--- a/package.json
+++ b/package.json
@@ -3,19 +3,24 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "start": "babel-node app.js --presets es2015,stage-2"
+    "start": "babel-node app.js --presets es2015,stage-2",
+    "dev": "babel-watch app.js --presets es2015,stage-2"
   },
   "dependencies": {
+    "async": "^2.0.1",
     "express": "^4.13.4",
     "mongodb-core": "^2.0.8",
     "mongodb-runner": "^3.3.2",
+    "node-fetch": "^1.6.0",
+    "parse": "^1.9.1",
     "parse-server": "^2.2.17",
-    "parse-server-mailgun": "^2.1.7",
+    "parse-server-amazon-ses-email-adapter": "^1.0.0",
     "parse-server-s3-adapter": "^1.0.4"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",
     "babel-preset-es2015": "^6.13.2",
-    "babel-preset-stage-2": "^6.13.0"
+    "babel-preset-stage-2": "^6.13.0",
+    "babel-watch": "^2.0.2"
   }
 }

--- a/templates/forgot_password_email.html
+++ b/templates/forgot_password_email.html
@@ -7,8 +7,8 @@
     <tr style="vertical-align: top; padding: 0;">
         <td valign="top" style="vertical-align: top; padding: 0;">
             <p style="margin: 20px 0;">Hi {{username}},</p>
-            <p style="margin: 20px 0;">Copy the token below and paste it into the GoodQuestion app:</p>
-            <p style="margin: 20px 0;"><blockquote>{{token}}</blockquote></p>
+            <p style="margin: 20px 0;">To reset your password, follow the link or copy the token then paste into the GoodQuestion app.</p>
+            <p style="margin: 20px 0;"><code><a href={{link}} href="http://goodquestion.eha.io/verifyForgotPassword" href={{link}}>{{token}}</a></code></p>
             <p style="margin: 20px 0;">If you don't wish to reset your password, disregard this email and no action will be taken.</p>
             <p style="margin: 20px 0;">The GoodQuestion Team<br /><a href="https://apps.eha.io" style="color: #9c27b0;">https://apps.eha.io</a></p>
         </td>

--- a/templates/forgot_password_email.html
+++ b/templates/forgot_password_email.html
@@ -1,0 +1,18 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+</head>
+<body style="width: 100% !important; -webkit-text-size-adjust: none; margin: 0; padding: 20;">
+<table style="border-spacing: 0; border-collapse: collapse; font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; width: 100% !important; height: 100% !important; color: #4c4c4c; font-size: 15px; line-height: 150%; background: #ffffff; margin: 0; padding: 0; border: 0;">
+    <tr style="vertical-align: top; padding: 0;">
+        <td valign="top" style="vertical-align: top; padding: 0;">
+            <p style="margin: 20px 0;">Hi {{username}},</p>
+            <p style="margin: 20px 0;">Copy the token below and paste it into the GoodQuestion app:</p>
+            <p style="margin: 20px 0;"><blockquote>{{token}}</blockquote></p>
+            <p style="margin: 20px 0;">If you don't wish to reset your password, disregard this email and no action will be taken.</p>
+            <p style="margin: 20px 0;">The GoodQuestion Team<br /><a href="https://apps.eha.io" style="color: #9c27b0;">https://apps.eha.io</a></p>
+        </td>
+    </tr>
+</table>
+</body>
+</html>

--- a/templates/forgot_password_email.txt
+++ b/templates/forgot_password_email.txt
@@ -1,6 +1,6 @@
 Hi {{username}},
 
-Copy the token below and paste it into the GoodQuestion app:
+To reset your password, copy the token below and paste it into the GoodQuestion app.
 
 {{token}}
 

--- a/templates/forgot_password_email.txt
+++ b/templates/forgot_password_email.txt
@@ -1,0 +1,10 @@
+Hi {{username}},
+
+Copy the token below and paste it into the GoodQuestion app:
+
+{{token}}
+
+If you don't wish to reset your password, disregard this email and no action will be taken.
+
+The GoodQuestion Team
+https://apps.eha.io

--- a/templates/test_email.html
+++ b/templates/test_email.html
@@ -1,0 +1,16 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+</head>
+<body style="width: 100% !important; -webkit-text-size-adjust: none; margin: 0; padding: 20;">
+<table style="border-spacing: 0; border-collapse: collapse; font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; width: 100% !important; height: 100% !important; color: #4c4c4c; font-size: 15px; line-height: 150%; background: #ffffff; margin: 0; padding: 0; border: 0;">
+    <tr style="vertical-align: top; padding: 0;">
+        <td valign="top" style="vertical-align: top; padding: 0;">
+            <p style="margin: 20px 0;">Hi {{username}},</p>
+            <p style="margin: 20px 0;">This is a test</p>
+            <p style="margin: 20px 0;">The GoodQuestion Team<br /><a href="https://apps.eha.io" style="color: #9c27b0;">https://apps.eha.io</a></p>
+        </td>
+    </tr>
+</table>
+</body>
+</html>

--- a/templates/test_email.txt
+++ b/templates/test_email.txt
@@ -1,0 +1,7 @@
+Hi {{username}},
+
+This is a test.
+
+
+The GoodQuestion Team
+https://apps.eha.io


### PR DESCRIPTION
Adds feature for forgotten password/reset:
- uses cloud code to create a ForgotPassword model
- emails the user a token with a link to the server /verifyForgotPassword
- server redirects the user with the custom deeplink scheme
- GQ app launches with email and token as params to the VerfityForgotPasswordPage
